### PR TITLE
Fix LazyFormatter.vformat

### DIFF
--- a/lazy_format/formatter.py
+++ b/lazy_format/formatter.py
@@ -3,6 +3,13 @@ import string
 
 
 class LazyFormatter(string.Formatter):
+    def vformat(self, format_string, args, kwargs):
+        # this code is copied almomst exactly from strings.py.
+        used_args = set()
+        result = self._vformat(format_string, args, kwargs, used_args, 2)
+        self.check_unused_args(used_args, args, kwargs)
+        return result
+    
     def _unsplit_var(self, conversion, field_name, format_spec):
         variable = (
             '{',
@@ -36,7 +43,6 @@ class LazyFormatter(string.Formatter):
                     rendered = self._unsplit_var(conversion, field_name, format_spec)
 
                 result.append(rendered)
-
         return ''.join(result)
 
 

--- a/lazy_format/formatter.py
+++ b/lazy_format/formatter.py
@@ -4,7 +4,7 @@ import string
 
 class LazyFormatter(string.Formatter):
     def vformat(self, format_string, args, kwargs):
-        # this code is copied almomst exactly from strings.py.
+        # this code is copied almost exactly from strings.py.
         used_args = set()
         result = self._vformat(format_string, args, kwargs, used_args, 2)
         self.check_unused_args(used_args, args, kwargs)


### PR DESCRIPTION
Changes to `vformat` and `_vformat` in `string.Formatter` have broken the `vformat` method in the `LazyFormatter` class. These commits add a `vformat` method to the `LazyFormatter` to allow the library to work with newer versions of Python.